### PR TITLE
Fix issue with jQuery is not defined

### DIFF
--- a/django_task/static/js/django_task.js
+++ b/django_task/static/js/django_task.js
@@ -1,4 +1,4 @@
-window.DjangoTask = (function($) {
+function initDjangoTask($) {
 
     $(document).ready(function() {
         var body = $('body');
@@ -108,4 +108,8 @@ window.DjangoTask = (function($) {
         update_tasks: update_tasks
     };
 
-})(jQuery);
+}
+
+window.addEventListener("load", function () {
+  window.DjangoTask = initDjangoTask(window.$ || window.jQuery || window.django.jQuery);
+})


### PR DESCRIPTION
Attempting to use the task admin page without jQuery loaded in the Django admin will fail and result in this error. So the statuses of the tasks are never updated.

```
ReferenceError: jQuery is not defined
```

Since Django already comes with jQuery bundled, I figured it would be nice to just use that. While also give the ability to use another version if the admin is already using that. So this should be completely backwards compatible. 

---

- Waiting for page load means that the django.jQuery is most likely available. This avoids loading a second version of jQuery for this script to work.
- If another version of jQuery is loaded, prefer that instead of the Django version.